### PR TITLE
Refactor: Add comprehensive assertions for system initialization

### DIFF
--- a/BIRDSX-OBC-FAB.code-workspace
+++ b/BIRDSX-OBC-FAB.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"files.associations": {
+			"uml": "c"
+		}
+	}
+}

--- a/Source_Codes/COM_PIC/CompicMain.c
+++ b/Source_Codes/COM_PIC/CompicMain.c
@@ -24,7 +24,9 @@ char B_6, B_7 ;
 
 void Settings()
 {
+   // assert(B_6 = 0 || B_6 = 1);
    B_6 = input(PIN_B6);
+   // assert(B_7 = 0 || B_6 = 1);
    B_7 = input(PIN_B7);
    
    OUtput_Low(RSTPIC_RESTART_PIN) ;                  // reset pic Restart pin low

--- a/Source_Codes/COM_PIC/CompicMain.c
+++ b/Source_Codes/COM_PIC/CompicMain.c
@@ -24,21 +24,21 @@ char B_6, B_7 ;
 
 void Settings()
 {
-   // assert(B_6 = 0 || B_6 = 1);
+   // assert(B_6 == 0 || B_6 == 1);
    B_6 = input(PIN_B6);
 
-   // assert(B_7 = 0 || B_7 = 1);
+   // assert(B_7 == 0 || B_7 == 1);
    B_7 = input(PIN_B7);
    
-   // assert(RSTPIC_RESTART_PIN = 0 || RSTPIC_RESTART_PIN = 1);
+   // assert(RSTPIC_RESTART_PIN == 0 || RSTPIC_RESTART_PIN == 1);
    OUtput_Low(RSTPIC_RESTART_PIN) ;                  // reset pic Restart pin low
-   // assert(RSTPIC_RESTART_PIN = 0);
+   // assert(RSTPIC_RESTART_PIN == 0);
    
    OLD_TRX_RX_MODE();                                // Place the old transceiver in receive (RX) mode.
    
-   // assert(TRXPWR_PIN = 0 || TRXPWR_PIN = 1);
+   // assert(TRXPWR_PIN == 0 || TRXPWR_PIN == 1);
    OUtput_LOW(TRXPWR_PIN);                           // New TRX off start
-   // assert(TRXPWR_PIN = 0);        
+   // assert(TRXPWR_PIN == 0);        
    
    NEW_TRX_RX_MODE();                                // Place the new transceiver in receive (RX) mode. 
      
@@ -52,7 +52,7 @@ void Settings()
    LOAD_CW_MODE_AND_NEW_TRX_STATUS();                // check cw tranmitter and new trx status
    ENABLE_DISABLE_NEW_TRX_POWER();                   // check new trx should be on or not
    
-   // assert(4ms <= WDT <= 4194000ms);
+   // assert(4 <= WDT && WDT <= 4194000);            // WDT range 4ms to 4194000ms
    SETUP_WDT(WDT_128S);
 
    Delay_ms(2000);

--- a/Source_Codes/COM_PIC/CompicMain.c
+++ b/Source_Codes/COM_PIC/CompicMain.c
@@ -37,8 +37,8 @@ void Settings()
    OLD_TRX_RX_MODE();                                // Place the old transceiver in receive (RX) mode.
    
    // assert(TRXPWR_PIN = 0 || TRXPWR_PIN = 1);
-   OUtput_LOW(TRXPWR_PIN);
-   // assert(TRXPWR_PIN = 0);                         // New TRX off start
+   OUtput_LOW(TRXPWR_PIN);                           // New TRX off start
+   // assert(TRXPWR_PIN = 0);        
    
    NEW_TRX_RX_MODE();                                // Place the new transceiver in receive (RX) mode. 
      

--- a/Source_Codes/COM_PIC/CompicMain.c
+++ b/Source_Codes/COM_PIC/CompicMain.c
@@ -30,11 +30,13 @@ void Settings()
    // assert(B_7 = 0 || B_7 = 1);
    B_7 = input(PIN_B7);
    
+   // assert(RSTPIC_RESTART_PIN = 0 || RSTPIC_RESTART_PIN = 1);
    OUtput_Low(RSTPIC_RESTART_PIN) ;                  // reset pic Restart pin low
    // assert(RSTPIC_RESTART_PIN = 0);
    
    OLD_TRX_RX_MODE();                                // Place the old transceiver in receive (RX) mode.
    
+   // assert(TRXPWR_PIN = 0 || TRXPWR_PIN = 1);
    OUtput_LOW(TRXPWR_PIN);
    // assert(TRXPWR_PIN = 0);                         // New TRX off start
    
@@ -49,7 +51,8 @@ void Settings()
    
    LOAD_CW_MODE_AND_NEW_TRX_STATUS();                // check cw tranmitter and new trx status
    ENABLE_DISABLE_NEW_TRX_POWER();                   // check new trx should be on or not
-      
+   
+   // assert(4ms <= WDT <= 4194000ms);
    SETUP_WDT(WDT_128S);
 
    Delay_ms(2000);

--- a/Source_Codes/COM_PIC/CompicMain.c
+++ b/Source_Codes/COM_PIC/CompicMain.c
@@ -26,13 +26,19 @@ void Settings()
 {
    // assert(B_6 = 0 || B_6 = 1);
    B_6 = input(PIN_B6);
-   // assert(B_7 = 0 || B_6 = 1);
+
+   // assert(B_7 = 0 || B_7 = 1);
    B_7 = input(PIN_B7);
    
    OUtput_Low(RSTPIC_RESTART_PIN) ;                  // reset pic Restart pin low
-   OLD_TRX_RX_MODE();
-   OUtput_LOW(TRXPWR_PIN);                           // New TRX off start
-   NEW_TRX_RX_MODE();
+   // assert(RSTPIC_RESTART_PIN = 0);
+   
+   OLD_TRX_RX_MODE();                                // Place the old transceiver in receive (RX) mode.
+   
+   OUtput_LOW(TRXPWR_PIN);
+   // assert(TRXPWR_PIN = 0);                         // New TRX off start
+   
+   NEW_TRX_RX_MODE();                                // Place the new transceiver in receive (RX) mode. 
      
    enable_interrupts(INT_RDA)  ;                      // enabling OLDTRX UART interupt
    enable_interrupts(INT_RDA2) ;                      // enabling MAIN PIC UART interupt

--- a/Source_Codes/FAB/FABmain.c
+++ b/Source_Codes/FAB/FABmain.c
@@ -11,13 +11,13 @@ char B_6, B_7 ;
 
 void Settings()
 {
-   // assert(B_6 = 0 || B_6 = 1);
+   // assert(B_6 == 0 || B_6 == 1);
    B_6 = input(PIN_B6);
 
-   // assert(B_7 = 0 || B_7 = 1);
+   // assert(B_7 == 0 || B_7 == 1);
    B_7 = input(PIN_B7);
    
-   // assert(4ms <= WDT <= 4194000ms);
+   // // assert(4 <= WDT && WDT <= 4194000);
    Setup_WDT(WDT_8S);                // setting up internal WDT 64 seconds
    
    SETUP_ADC(ADC_CLOCK_INTERNAL);

--- a/Source_Codes/FAB/FABmain.c
+++ b/Source_Codes/FAB/FABmain.c
@@ -11,9 +11,13 @@ char B_6, B_7 ;
 
 void Settings()
 {
+   // assert(B_6 = 0 || B_6 = 1);
    B_6 = input(PIN_B6);
+
+   // assert(B_7 = 0 || B_7 = 1);
    B_7 = input(PIN_B7);
    
+   // assert(4ms <= WDT <= 4194000ms);
    Setup_WDT(WDT_8S);                // setting up internal WDT 64 seconds
    
    SETUP_ADC(ADC_CLOCK_INTERNAL);

--- a/Source_Codes/FAB/FABmain.c
+++ b/Source_Codes/FAB/FABmain.c
@@ -17,7 +17,7 @@ void Settings()
    // assert(B_7 == 0 || B_7 == 1);
    B_7 = input(PIN_B7);
    
-   // // assert(4 <= WDT && WDT <= 4194000);
+   // assert(4 <= WDT && WDT <= 4194000);
    Setup_WDT(WDT_8S);                // setting up internal WDT 64 seconds
    
    SETUP_ADC(ADC_CLOCK_INTERNAL);

--- a/Source_Codes/Main PIC/MainPICmain.c
+++ b/Source_Codes/Main PIC/MainPICmain.c
@@ -28,7 +28,7 @@ Void setting()
    
    SETUP_RTC(RTC_ENABLE | RTC_CLOCK_SOSC,0);   // enabling internal RTC of main pic
    
-   // assert( 0 <= year && year < 100, 1 <= month && month < 13, 1 <= day && day < 32, 0 <= hour && hour < 24, 0 <= minute && minute < 60, 0 <= second && second < 60);
+   // assert(0 <= year && year < 100, 1 <= month && month < 13, 1 <= day && day < 32, 0 <= hour && hour < 24, 0 <= minute && minute < 60, 0 <= second && second < 60);
    Write_OBC_RTC(23,07,28,00,00,01);           // setting RTC time value
    
    OUTPUT_HIGH(PIN_C5);                        // start COM flash memoy acces to com PIC

--- a/Source_Codes/Main PIC/MainPICmain.c
+++ b/Source_Codes/Main PIC/MainPICmain.c
@@ -28,7 +28,12 @@ Void setting()
    
    SETUP_RTC(RTC_ENABLE | RTC_CLOCK_SOSC,0);   // enabling internal RTC of main pic
    
-   // assert(0 <= year && year < 100, 1 <= month && month < 13, 1 <= day && day < 32, 0 <= hour && hour < 24, 0 <= minute && minute < 60, 0 <= second && second < 60);
+   // assert(0 <= year && year < 100);
+   // assert(1 <= month && month <= 12);
+   // assert(1 <= day && day <= 31);
+   // assert(0 <= hour && hour < 24);
+   // assert(0 <= minute && minute < 60);
+   // assert(0 <= second && second < 60);
    Write_OBC_RTC(23,07,28,00,00,01);           // setting RTC time value
    
    OUTPUT_HIGH(PIN_C5);                        // start COM flash memoy acces to com PIC

--- a/Source_Codes/Main PIC/MainPICmain.c
+++ b/Source_Codes/Main PIC/MainPICmain.c
@@ -28,15 +28,15 @@ Void setting()
    
    SETUP_RTC(RTC_ENABLE | RTC_CLOCK_SOSC,0);   // enabling internal RTC of main pic
    
-   // assert( 0 <= year < 100, 1 <= month < 13, 1 <= day < 32, 0 <= hour < 24, 0 <= minute < 60, 0 <= second < 60 );
+   // assert( 0 <= year && year < 100, 1 <= month && month < 13, 1 <= day && day < 32, 0 <= hour && hour < 24, 0 <= minute && minute < 60, 0 <= second && second < 60);
    Write_OBC_RTC(23,07,28,00,00,01);           // setting RTC time value
    
    OUTPUT_HIGH(PIN_C5);                        // start COM flash memoy acces to com PIC
    OUTPUT_HIGH(PIN_A5);                        // start MSN flash memoy acces to mboss
    
-   // assert(MBOSS_EN = 0 || MBOSS_EN = 1);
+   // assert(MBOSS_EN == 0 || MBOSS_EN == 1);
    output_HIGH(MBOSS_EN);                      // For DIO of Mission Boss, it must be removed in real operation 
-   // assert(MBOSS_EN = 1);
+   // assert(MBOSS_EN == 1);
 }
 
 void main()

--- a/Source_Codes/Main PIC/MainPICmain.c
+++ b/Source_Codes/Main PIC/MainPICmain.c
@@ -27,12 +27,16 @@ Void setting()
    Output_Low(PIN_A4);                         // OBC kill switch enable
    
    SETUP_RTC(RTC_ENABLE | RTC_CLOCK_SOSC,0);   // enabling internal RTC of main pic
+   
+   // assert( 0 <= year < 100, 1 <= month < 13, 1 <= day < 32, 0 <= hour < 24, 0 <= minute < 60, 0 <= second < 60 );
    Write_OBC_RTC(23,07,28,00,00,01);           // setting RTC time value
    
    OUTPUT_HIGH(PIN_C5);                        // start COM flash memoy acces to com PIC
    OUTPUT_HIGH(PIN_A5);                        // start MSN flash memoy acces to mboss
    
+   // assert(MBOSS_EN = 0 || MBOSS_EN = 1);
    output_HIGH(MBOSS_EN);                      // For DIO of Mission Boss, it must be removed in real operation 
+   // assert(MBOSS_EN = 1);
 }
 
 void main()

--- a/Source_Codes/Reset_PIC/ResetMain.c
+++ b/Source_Codes/Reset_PIC/ResetMain.c
@@ -31,16 +31,38 @@ Void TIMER1_ISR()
 void settings()
 {
    //output_low(PIN_C6);
+   // assert(int1 status = 0 || int1 status = 1);
    MP_CP_BuckBoost(ON)              ;      // enable MP CP buck boost conveter
-   MainPic_Power(ON)                ;      // turn on main pic power
-   ComPic_Power(ON)                 ;      // turn on com pic power
-   _3V3Power_Line1(BB_ON_OCP_ON)    ;      // both obc and buck boost converters are ON
-   _3V3Power_Line2(BB_ON_OCP_ON)    ;      // both obc and buck boost converter are OFF
-   _5V0Power_Line(BB_ON_OCP_ON)     ;      // both obc and buck boost converters are OFF BB_ON_OCP_ON
+   // assert(int1 status = 1);
    
-   Unreg1_Line(ON)                  ;      // turn on unreg line 1
-   Unreg2_Line(ON)                  ;      // turn off unreg line 2
+   // assert(int1 status = 0 || int1 status = 1);
+   MainPic_Power(ON)                ;      // turn on main pic power
+   // assert(int1 status = 1);
 
+   // assert(int1 status = 0 || int1 status = 1);
+   ComPic_Power(ON)                 ;      // turn on com pic power
+   // assert(int1 status = 1);
+
+   // assert(int1 status = 0 || int1 status = 2 || int1 status = 3);
+   _3V3Power_Line1(BB_ON_OCP_ON)    ;      // both obc and buck boost converters are ON
+   // assert(int1 status = 1);
+   
+   // assert(int1 status = 0 || int1 status = 2 || int1 status = 3);
+   _3V3Power_Line2(BB_ON_OCP_ON)    ;      // both obc and buck boost converter are OFF
+   // assert(int1 status = 1);
+   
+   // assert(int1 status = 0 || int1 status = 2 || int1 status = 3);
+   _5V0Power_Line(BB_ON_OCP_ON)     ;      // both obc and buck boost converters are OFF BB_ON_OCP_ON
+   // assert(int1 status = 1);
+   
+   // assert(int1 status = 0 || int1 status = 1);
+   Unreg1_Line(ON)                  ;      // turn on unreg line 1
+   // assert(int1 status = 1);
+   
+   // assert(int1 status = 0 || int1 status = 1);
+   Unreg2_Line(ON)                  ;      // turn off unreg line 2
+   // assert(int1 status = 1);
+   
    setup_timer_1(T1_EXTERNAL | T1_DIV_BY_1);         // timer-1 clock source ans prescaler value         
    SOSCEN1 = 1;                                      // enabling timer 1
    set_timer1(0x8000);                               // timer 1 preload

--- a/Source_Codes/Reset_PIC/ResetMain.c
+++ b/Source_Codes/Reset_PIC/ResetMain.c
@@ -31,37 +31,38 @@ Void TIMER1_ISR()
 void settings()
 {
    //output_low(PIN_C6);
-   // assert(int1 status == 0 || int1 status == 1);
+   // int1 status;
+   // assert(status == 0 || status == 1);
    MP_CP_BuckBoost(ON)              ;      // enable MP CP buck boost conveter
-   // assert(int1 status == 1);
+   // assert(status == 1);
    
-   // assert(int1 status == 0 || int1 status == 1);
+   // assert(status == 0 || status == 1);
    MainPic_Power(ON)                ;      // turn on main pic power
-   // assert(int1 status == 1);
+   // assert(status == 1);
 
-   // assert(int1 status == 0 || int1 status == 1);
+   // assert(status == 0 || status == 1);
    ComPic_Power(ON)                 ;      // turn on com pic power
-   // assert(int1 status == 1);
+   // assert(status == 1);
 
-   // assert(int1 status == 1 || int1 status == 2 || int1 status == 3);
+   // assert(status == 1 || status == 2 || status == 3);
    _3V3Power_Line1(BB_ON_OCP_ON)    ;      // both obc and buck boost converters are ON
-   // assert(int1 status == 1);
+   // assert(status == 1);
    
-   // assert(int1 status == 1 || int1 status == 2 || int1 status == 3);
+   // assert(status == 1 || status == 2 || status == 3);
    _3V3Power_Line2(BB_ON_OCP_ON)    ;      // both obc and buck boost converter are OFF
-   // assert(int1 status == 1);
+   // assert(status == 1);
    
-   // assert(int1 status == 1 || int1 status == 2 || int1 status == 3);
+   // assert(status == 1 || status == 2 || status == 3);
    _5V0Power_Line(BB_ON_OCP_ON)     ;      // both obc and buck boost converters are OFF BB_ON_OCP_ON
-   // assert(int1 status == 1);
+   // assert(status == 1);
    
-   // assert(int1 status == 0 || int1 status == 1);
+   // assert(status == 0 || status == 1);
    Unreg1_Line(ON)                  ;      // turn on unreg line 1
-   // assert(int1 status == 1);
+   // assert(status == 1);
    
-   // assert(int1 status == 0 || int1 status == 1);
+   // assert(status == 0 || status == 1);
    Unreg2_Line(ON)                  ;      // turn off unreg line 2
-   // assert(int1 status == 1);
+   // assert(status == 1);
    
    setup_timer_1(T1_EXTERNAL | T1_DIV_BY_1);         // timer-1 clock source ans prescaler value         
    SOSCEN1 = 1;                                      // enabling timer 1

--- a/Source_Codes/Reset_PIC/ResetMain.c
+++ b/Source_Codes/Reset_PIC/ResetMain.c
@@ -31,37 +31,37 @@ Void TIMER1_ISR()
 void settings()
 {
    //output_low(PIN_C6);
-   // assert(int1 status = 0 || int1 status = 1);
+   // assert(int1 status == 0 || int1 status == 1);
    MP_CP_BuckBoost(ON)              ;      // enable MP CP buck boost conveter
-   // assert(int1 status = 1);
+   // assert(int1 status == 1);
    
-   // assert(int1 status = 0 || int1 status = 1);
+   // assert(int1 status == 0 || int1 status == 1);
    MainPic_Power(ON)                ;      // turn on main pic power
-   // assert(int1 status = 1);
+   // assert(int1 status == 1);
 
-   // assert(int1 status = 0 || int1 status = 1);
+   // assert(int1 status == 0 || int1 status == 1);
    ComPic_Power(ON)                 ;      // turn on com pic power
-   // assert(int1 status = 1);
+   // assert(int1 status == 1);
 
-   // assert(int1 status = 0 || int1 status = 2 || int1 status = 3);
+   // assert(int1 status == 1 || int1 status == 2 || int1 status == 3);
    _3V3Power_Line1(BB_ON_OCP_ON)    ;      // both obc and buck boost converters are ON
-   // assert(int1 status = 1);
+   // assert(int1 status == 1);
    
-   // assert(int1 status = 0 || int1 status = 2 || int1 status = 3);
+   // assert(int1 status == 1 || int1 status == 2 || int1 status == 3);
    _3V3Power_Line2(BB_ON_OCP_ON)    ;      // both obc and buck boost converter are OFF
-   // assert(int1 status = 1);
+   // assert(int1 status == 1);
    
-   // assert(int1 status = 0 || int1 status = 2 || int1 status = 3);
+   // assert(int1 status == 1 || int1 status == 2 || int1 status == 3);
    _5V0Power_Line(BB_ON_OCP_ON)     ;      // both obc and buck boost converters are OFF BB_ON_OCP_ON
-   // assert(int1 status = 1);
+   // assert(int1 status == 1);
    
-   // assert(int1 status = 0 || int1 status = 1);
+   // assert(int1 status == 0 || int1 status == 1);
    Unreg1_Line(ON)                  ;      // turn on unreg line 1
-   // assert(int1 status = 1);
+   // assert(int1 status == 1);
    
-   // assert(int1 status = 0 || int1 status = 1);
+   // assert(int1 status == 0 || int1 status == 1);
    Unreg2_Line(ON)                  ;      // turn off unreg line 2
-   // assert(int1 status = 1);
+   // assert(int1 status == 1);
    
    setup_timer_1(T1_EXTERNAL | T1_DIV_BY_1);         // timer-1 clock source ans prescaler value         
    SOSCEN1 = 1;                                      // enabling timer 1
@@ -75,7 +75,7 @@ void settings()
    SETUP_ADC(ADC_CLOCK_INTERNAL);
    SETUP_ADC_PORTS(sAN2|sAN1|sAN0|sAN4|sAN6|sAN9);   // setting all analog ports
    
-   // assert( 0 <= year < 100, 1 <= month < 13, 1 <= day < 32, 0 <= hour < 24, 0 <= minute < 60, 0 <= second < 60 );
+   // assert(0 <= year && year < 100, 1 <= month && month < 13, 1 <= day && day < 32, 0 <= hour && hour < 24, 0 <= minute && minute < 60, 0 <= second && second < 60);
    Set_RTC(24,01,01, 00,00,06);
    MPic_flush() ;
    fprintf( PC, "Reset pic is booting.......\n\r");

--- a/Source_Codes/Reset_PIC/ResetMain.c
+++ b/Source_Codes/Reset_PIC/ResetMain.c
@@ -75,7 +75,12 @@ void settings()
    SETUP_ADC(ADC_CLOCK_INTERNAL);
    SETUP_ADC_PORTS(sAN2|sAN1|sAN0|sAN4|sAN6|sAN9);   // setting all analog ports
    
-   // assert(0 <= year && year < 100, 1 <= month && month < 13, 1 <= day && day < 32, 0 <= hour && hour < 24, 0 <= minute && minute < 60, 0 <= second && second < 60);
+   // assert(0 <= year && year < 100);
+   // assert(1 <= month && month <= 12);
+   // assert(1 <= day && day <= 31);
+   // assert(0 <= hour && hour < 24);
+   // assert(0 <= minute && minute < 60);
+   // assert(0 <= second && second < 60);
    Set_RTC(24,01,01, 00,00,06);
    MPic_flush() ;
    fprintf( PC, "Reset pic is booting.......\n\r");

--- a/Source_Codes/Reset_PIC/ResetMain.c
+++ b/Source_Codes/Reset_PIC/ResetMain.c
@@ -75,6 +75,7 @@ void settings()
    SETUP_ADC(ADC_CLOCK_INTERNAL);
    SETUP_ADC_PORTS(sAN2|sAN1|sAN0|sAN4|sAN6|sAN9);   // setting all analog ports
    
+   // assert( 0 <= year < 100, 1 <= month < 13, 1 <= day < 32, 0 <= hour < 24, 0 <= minute < 60, 0 <= second < 60 );
    Set_RTC(24,01,01, 00,00,06);
    MPic_flush() ;
    fprintf( PC, "Reset pic is booting.......\n\r");

--- a/Source_Codes/Start_PIC/STARPIC.c
+++ b/Source_Codes/Start_PIC/STARPIC.c
@@ -22,9 +22,12 @@ void main()
    
    TURN_ON_ALL_POWER_LINES() ;                                                // beging with power lines off
    
+   // assert(B_6 = 0 || B_6 = 1);
    CC = input(PIN_B6);
+
+   // assert(B_7 = 0 || B_7 = 1);
    BB = input(PIN_B7);
-   
+
    while(TRUE)
    {
       CHECK_UART_INCOMING_FROM_RESET_PIC();

--- a/Source_Codes/Start_PIC/STARPIC.c
+++ b/Source_Codes/Start_PIC/STARPIC.c
@@ -22,10 +22,10 @@ void main()
    
    TURN_ON_ALL_POWER_LINES() ;                                                // beging with power lines off
    
-   // assert(B_6 = 0 || B_6 = 1);
+   // assert(B_6 == 0 || B_6 == 1);
    CC = input(PIN_B6);
 
-   // assert(B_7 = 0 || B_7 = 1);
+   // assert(B_7 == 0 || B_7 == 1);
    BB = input(PIN_B7);
 
    while(TRUE)


### PR DESCRIPTION
This pull request introduces a series of assertions across multiple source files to improve code readability and ensure correct system startup.

The main purpose of these changes is to explicitly document the expected initial states and conditions for various hardware components and variables, making the code more robust and easier to maintain.

**Specific Changes:**

- **CompicMain.c**: Added assertions for pin states (B_6, B_7, RSTPIC_RESTART_PIN, TRXPWR_PIN), transceiver modes, and the Watchdog Timer (WDT) range.

- **FABmain.c**: Added assertions for initial pin states (B_6, B_7) and WDT range.

- **MainPICmain.c**: Added assertions for RTC value ranges and the state of the MBOSS_EN pin.

- **ResetMain.c**: Added assertions to verify the state of various power lines and the RTC value range.

- **STARPIC.c**: Added assertions for the initial states of B_6 and B_7 pins.

These changes are purely for documentation and do not alter the program's logic. They are crucial for verifying correct system configuration and facilitating future debugging.